### PR TITLE
fix: int enums display warnings on the IDE when hydration helpers are called

### DIFF
--- a/src/Concerns/Hydrates.php
+++ b/src/Concerns/Hydrates.php
@@ -18,7 +18,7 @@ trait Hydrates
      *
      * @throws ValueError
      */
-    public static function from(string $name): static
+    public static function from(int|string $name): static
     {
         return self::fromName($name);
     }
@@ -28,7 +28,7 @@ trait Hydrates
      *
      * @throws ValueError
      */
-    public static function fromName(string $name): static
+    public static function fromName(int|string $name): static
     {
         if ($case = self::tryFromName($name)) {
             return $case;
@@ -40,7 +40,7 @@ trait Hydrates
     /**
      * Retrieve the case hydrated from the given name or NULL.
      */
-    public static function tryFromName(string $name): ?static
+    public static function tryFromName(int|string $name): ?static
     {
         foreach (self::cases() as $case) {
             if ($case->name === $name) {
@@ -55,7 +55,7 @@ trait Hydrates
      * Retrieve the case hydrated from the given name or NULL.
      * This method can be called by pure enums only.
      */
-    public static function tryFrom(string $name): ?static
+    public static function tryFrom(int|string $name): ?static
     {
         return self::tryFromName($name);
     }


### PR DESCRIPTION
## Description
int enums display warnings when we call Hydratation helpers with the PHPStorm IDE

## Screenshots
![image](https://github.com/user-attachments/assets/61b6c4be-a484-4b40-bebd-60cac7e50122)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

Tests already cover this case, see: https://github.com/jeremiealvin/enum/blob/42a31c90180e2bc653c4d58173673d5e3c299fdc/tests/Unit/BackedEnumTest.php#L297