### PR TITLE
ci: add tests for PHP 8.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.1, 8.2, 8.3, 8.4]
+                php: [8.1, 8.2, 8.3, 8.4, 8.5]
                 dependency-version: [prefer-lowest, prefer-stable]
                 os: [ubuntu-latest, windows-latest, macos-latest]
 
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -42,7 +42,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   tools: composer:v2
-                  coverage: none
+                  coverage: xdebug
 
             - name: Install dependencies
               run: |

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require-dev": {
         "pestphp/pest": "^2.36|^3.0|^4.0",
         "phpstan/phpstan": "^2.1.31",
-        "scrutinizer/ocular": "^1.9",
+        "uma/ocular": "^2.0",
         "squizlabs/php_codesniffer": "^3.13",
         "tightenco/duster": "^2.7.6|^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.1"
     },
     "require-dev": {
-        "pestphp/pest": "^2.0",
+        "pestphp/pest": "^2.36|^3.0|^4.0",
         "phpstan/phpstan": "^2.0",
         "scrutinizer/ocular": "^1.9",
         "squizlabs/php_codesniffer": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     },
     "require-dev": {
         "pestphp/pest": "^2.36|^3.0|^4.0",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.1.31",
         "scrutinizer/ocular": "^1.9",
-        "squizlabs/php_codesniffer": "^3.0",
-        "tightenco/duster": "^2.0"
+        "squizlabs/php_codesniffer": "^3.13",
+        "tightenco/duster": "^2.7.6|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I need to switch to a fork to make it work.
Please see https://github.com/scrutinizer-ci/ocular/pull/64

Linting error should be fixed in a seperate PR.
There a way to many testruns in my eyes. BUt i think this should be handled in a sperate PR as well.